### PR TITLE
Make cave spiders spawn from broken infested leaves

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ group= "uk.artdude.tweaks.twisted"
 archivesBaseName = "twistedtweaks"
 
 minecraft {
-    version = "1.10.2-12.18.2.2099"
+    version = "${minecraft_version}-${forge_version}"
     runDir = "run"
     mappings = "snapshot_20160518"
 	

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-mod_version=2.0.0
-minecraft_version=1.8.9
-forge_version=11.15.0.1718
+mod_version=0.4.0
+minecraft_version=1.10.2
+forge_version=12.18.2.2099

--- a/src/main/java/uk/artdude/tweaks/twisted/common/addons/TTAddons.java
+++ b/src/main/java/uk/artdude/tweaks/twisted/common/addons/TTAddons.java
@@ -10,6 +10,7 @@ import uk.artdude.tweaks.twisted.common.addons.acidrain.modules.CropAcidRain;
 import uk.artdude.tweaks.twisted.common.addons.acidrain.modules.MobAcidRain;
 import uk.artdude.tweaks.twisted.common.addons.acidrain.modules.PlayerAcidRain;
 import uk.artdude.tweaks.twisted.common.addons.modifications.IgniteBlocks;
+import uk.artdude.tweaks.twisted.common.addons.modifications.InfestedSpiders;
 import uk.artdude.tweaks.twisted.common.addons.modifications.StarveDeath;
 import uk.artdude.tweaks.twisted.common.addons.modifications.XPVoid;
 import uk.artdude.tweaks.twisted.common.addons.startinginventory.StartingInventory;
@@ -58,5 +59,7 @@ public class TTAddons {
             StartingInventory.init();
             MinecraftForge.EVENT_BUS.register(new StartingInventory());
         }
+        // Register spiders spawning from infested leaves.
+        MinecraftForge.EVENT_BUS.register(new InfestedSpiders());
     }
 }

--- a/src/main/java/uk/artdude/tweaks/twisted/common/addons/modifications/InfestedSpiders.java
+++ b/src/main/java/uk/artdude/tweaks/twisted/common/addons/modifications/InfestedSpiders.java
@@ -1,0 +1,39 @@
+package uk.artdude.tweaks.twisted.common.addons.modifications;
+
+import net.minecraft.world.World;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.entity.monster.EntityCaveSpider;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import uk.artdude.tweaks.twisted.common.configuration.ConfigurationHelper;
+
+public class InfestedSpiders {
+
+    /**
+     * This event gets fired when a player breaks a block and, in case the broken block is an
+     * infested leaves block, have a chance to spawn a cave spider.
+     * @param event The event of the block break.
+     */
+    @SubscribeEvent
+    public void blockBreak(BlockEvent.BreakEvent event) {
+        World world = event.getWorld();
+        String blockRegistryName = event.getState().getBlock().getRegistryName().toString();
+        boolean isInfestedLeaves = blockRegistryName.equals("exnihiloomnia:infested_leaves");
+        // If we're on the server side (don't want to spawn a client-only ghost spider) and the
+        // player is breaking an infested leaves block, ...
+        if (!world.isRemote && isInfestedLeaves) {
+            // Get the chance for a spider to spawn from it.
+            double chance = ConfigurationHelper.infestedLeavesSpiderChance;
+            // Generate a random number between 0.0 and 1.0 and see if the player is unlucky. >:)
+            if (world.rand.nextFloat() < chance) {
+                // Create the spider and set its position.
+                EntityCaveSpider spider = new EntityCaveSpider(world);
+                BlockPos pos = event.getPos();
+                float yaw = (world.rand.nextFloat() * 360.0F); // Get a random rotation.
+                spider.setPositionAndRotation(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, yaw, 0.0F);
+                // Spawn the spider in the world.
+                world.spawnEntityInWorld(spider);
+            }
+        }
+    }
+}

--- a/src/main/java/uk/artdude/tweaks/twisted/common/configuration/ConfigurationHelper.java
+++ b/src/main/java/uk/artdude/tweaks/twisted/common/configuration/ConfigurationHelper.java
@@ -41,6 +41,7 @@ public class ConfigurationHelper {
     // Block Changes
     public static boolean enableXPVoid;
     public static String[] oreXPDisabled;
+    public static double infestedLeavesSpiderChance;
 
     // Enchantments
     public static boolean enableGalvanized;

--- a/src/main/java/uk/artdude/tweaks/twisted/common/configuration/TTConfiguration.java
+++ b/src/main/java/uk/artdude/tweaks/twisted/common/configuration/TTConfiguration.java
@@ -85,6 +85,8 @@ public class TTConfiguration {
                             "minecraft:emerald_ore"
                     },
                     "This is the list of ores that you want to stop XP dropping upon mining.");
+            infestedLeavesSpiderChance = config.get("Infested Leaves Spider Chance", CATEGORY_TWEAKS, true, "Sets the chance of cave " +
+                    "spiders spawning from infested leaves when broken.").getDouble(0.02);
 
             // Enchantment configurations
             enableGalvanized = config.getBoolean("Enable Galvanized", CATEGORY_ENCHANTMENTS, true, "You can enable or disable the galvanized " +


### PR DESCRIPTION
As per request from @MindlessPuppetz. Disclaimer: Not tested!
I set the default chance to spawn a cave spider to to 2% (1 out of 50).
I do not test whether the infested leaves are done "growing".
Will fix if bugs are found or improvements need to be made.

I figured I'd update the `gradle.properties` and make use it in `build.gradle`.